### PR TITLE
add support for Dropbox API v2

### DIFF
--- a/lib/dropbox.js
+++ b/lib/dropbox.js
@@ -7,38 +7,56 @@
  */
 
 module.exports = function () {
-  'use strict';
-  var Promise = require('bluebird'),
-    request = Promise.promisify(require('request')),
-    accountInfoUrl = "https://api.dropbox.com/1/account/info",
-    uploadUrl = "https://api-content.dropbox.com/1/files_put/auto/";
+	'use strict';
+	var Promise = require('bluebird'),
+		request = Promise.promisify(require('request')),
+		accountInfoUrl = "https://api.dropboxapi.com/2/users/get_current_account",
+		uploadUrl = "https://content.dropboxapi.com/2/files/upload";
 
-  function parseBody(resp) {
-    return JSON.parse(resp[1]);
-  }
-  
-  this.getAccountInfo = function (options) {
-    var reqOptions = {
-      method: "GET",
-      url: accountInfoUrl,
-      auth: {
-        bearer: options.access_token
-      }
-    };
-    
-    return request(reqOptions).then(parseBody);
-  };
-  
-  this.upload = function (options) {
-    var reqOptions = {
-      method: "PUT",
-      body: options.fileBuffer,
-      url: uploadUrl + options.dropboxPath,
-      auth: {
-        bearer: options.access_token
-      }
-    };
-    
-    return request(reqOptions).then(parseBody);
-  };
+	function parseBody(resp) {
+	  console.log(resp);
+	return JSON.parse(resp[1]);
+	}
+
+	this.getAccountInfo = function (options) {
+		var reqOptions = {
+			method: "POST",
+			url: accountInfoUrl,
+			auth: {
+				bearer: options.access_token
+			}
+		};
+
+		return request(reqOptions).then(parseBody);
+	};
+
+	this.upload = function (options) {
+		var params = {
+			"path": options.dropboxPath,
+			"mode": "overwrite"
+		};
+		var paramsJSON = this.httpHeaderSafeJson(params);
+		var reqOptions = {
+			method: "POST",
+			headers: {
+				'Content-Type' : 'application/octet-stream',
+				'Dropbox-API-Arg': paramsJSON
+			},
+			body: options.fileBuffer,
+			url: uploadUrl,
+
+			auth: {
+				bearer: options.access_token
+			}
+		};
+
+		return request(reqOptions).then(parseBody);
+	};
+
+	this.httpHeaderSafeJson = function(args){
+		var charsToEncode = /[\u007f-\uffff]/g;
+		return JSON.stringify(args).replace(charsToEncode, function (c) {
+			return '\\u' + ('000' + c.charCodeAt(0).toString(16)).slice(-4);
+		});
+	}
 };

--- a/tasks/dropbox.js
+++ b/tasks/dropbox.js
@@ -10,7 +10,7 @@ module.exports = function (grunt) {
   'use strict';
   var Dropbox = require('../lib/dropbox'),
     dropboxClient = new Dropbox();
-  
+
   function getFilename(filepath) {
     var splitPath = filepath.split("/");
     return splitPath[splitPath.length - 1];
@@ -26,14 +26,14 @@ module.exports = function (grunt) {
     }
     return true;
   }
-  
+
   function hasDestination(file) {
     if(file.dest === undefined) {
       grunt.fail.fatal("a destination must be specified for all files");
     }
     return true;
   }
-  
+
   function verifyOptions(options) {
     ['access_token'].forEach(function (option) {
       if (!options[option]) {
@@ -41,13 +41,13 @@ module.exports = function (grunt) {
       }
     });
   }
-  
+
   // returns a function that creates a promise to upload the file to the destination
   function createUploadPromise(filepath, destination, options) {
     return function () {
       // get the name of the file and construct the url for uploading it
       var filename = getFilename(filepath),
-        dropboxPath = destination + (options.version_name ? ("/" + options.version_name + "/") : "/") + filename,
+        dropboxPath = destination + (options.version_name ? ("/" + options.version_name + "/") : "/") + filepath,
         // read the file and start the upload, decrementing the in-flight count when complete
         // Use encoding = null to keep the file as a Buffer
         reqOptions = {
@@ -57,7 +57,7 @@ module.exports = function (grunt) {
         };
 
       grunt.log.writeln("Uploading " + filepath + " to " + dropboxPath + "...");
-      
+
       // return the upload promise
       return dropboxClient.upload(reqOptions);
     };
@@ -69,16 +69,16 @@ module.exports = function (grunt) {
       promise,
       done = this.async(),
       options = this.options({ verbose: false });
-    
+
     verifyOptions(options);
-    
+
     // get the name of the account holder for debugging
     if(options.verbose === true) {
       promise = dropboxClient.getAccountInfo(options).then(function (resp) {
-        grunt.log.writeln("Uploading to dropbox account for " + resp.display_name + "...");
-      }); 
+        grunt.log.writeln("Uploading to dropbox account for " + resp.name.display_name + "...");
+      });
     }
-    
+
     // loop through all the file objects
     task.files.filter(hasDestination).forEach(function (f) {
       // loop through all the src files, uploading them
@@ -94,7 +94,7 @@ module.exports = function (grunt) {
         }
       });
     });
-    
+
     // well all the continuations are done, finish this async task
     promise.then(function () {
       done();


### PR DESCRIPTION
Dropbox has announced that v1 will be turned off on September 28, 2017: https://blogs.dropbox.com/developers/2016/06/api-v1-deprecated/

This pull request adds support for the Dropbox API v2. 